### PR TITLE
Updated interfaces for optional upload progress callback

### DIFF
--- a/CreateAR.Commons.Unity.Http/CreateAR.Commons.Unity.Http.csproj
+++ b/CreateAR.Commons.Unity.Http/CreateAR.Commons.Unity.Http.csproj
@@ -1,18 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net35</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <AssemblyName>CreateAR.Commons.Unity.Http</AssemblyName>
     <RootNamespace>CreateAR.Commons.Unity.Http</RootNamespace>
-    <AssemblyVersion>0.13.4</AssemblyVersion>
-    <Version>0.13.4</Version>
+    <AssemblyVersion>0.13.5</AssemblyVersion>
+    <Version>0.13.5</Version>
     <Description>For working with HTTP services.</Description>
-    <Copyright>Copyright © 2019 Enklu</Copyright>
+    <Copyright>Copyright © 2020 Enklu</Copyright>
     <Authors>Enklu</Authors>
     <IncludeSymbols>True</IncludeSymbols>
-    <PackageReleaseNotes>Added more granular controls for file upload.</PackageReleaseNotes>
-    <FileVersion>0.13.3</FileVersion>
+    <PackageReleaseNotes>Added ProgressHttpContent</PackageReleaseNotes>
+    <FileVersion>0.13.5</FileVersion>
     <Company>Enklu</Company>
+    <PackageId>CreateAR.Commons.Unity.Http</PackageId>
+    <PackageVersion>0.13.5</PackageVersion>
+    <Product>CreateAR.Commons.Unity.Http</Product>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugType>full</DebugType>

--- a/CreateAR.Commons.Unity.Http/HttpResponse.cs
+++ b/CreateAR.Commons.Unity.Http/HttpResponse.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using CreateAR.Commons.Unity.DataStructures;
+﻿using System;
+using System.Collections.Generic;
 
 namespace CreateAR.Commons.Unity.Http
 {

--- a/CreateAR.Commons.Unity.Http/HttpService.cs
+++ b/CreateAR.Commons.Unity.Http/HttpService.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using CreateAR.Commons.Unity.Async;
-using CreateAR.Commons.Unity.DataStructures;
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -113,13 +112,18 @@ namespace CreateAR.Commons.Unity.Http
             IEnumerable<Tuple<string, string>> fields,
             ref byte[] file,
             int offset,
-            int count)
+            int count,
+            Action<float> progress = null)
         {
             return SendFile<T>(HttpVerb.Post, url, fields, ref file);
         }
 
         /// <inheritdoc />
-        public IAsyncToken<HttpResponse<T>> PostFile<T>(string url, IEnumerable<Tuple<string, string>> fields, Stream file)
+        public IAsyncToken<HttpResponse<T>> PostFile<T>(
+            string url, 
+            IEnumerable<Tuple<string, string>> fields, 
+            Stream file,
+            Action<float> progress = null)
         {
             // Attempt to grab all data. Might not work in every situation.
             var data = new byte[file.Length];
@@ -133,13 +137,18 @@ namespace CreateAR.Commons.Unity.Http
             IEnumerable<Tuple<string, string>> fields,
             ref byte[] file,
             int offset,
-            int count)
+            int count,
+            Action<float> progressCallback = null)
         {
             return SendFile<T>(HttpVerb.Put, url, fields, ref file);
         }
 
         /// <inheritdoc />
-        public IAsyncToken<HttpResponse<T>> PutFile<T>(string url, IEnumerable<Tuple<string, string>> fields, Stream file)
+        public IAsyncToken<HttpResponse<T>> PutFile<T>(
+            string url, 
+            IEnumerable<Tuple<string, string>> fields, 
+            Stream file,
+            Action<float> progressCallback = null)
         {
             // Attempt to grab all data. Might not work in every situation.
             var data = new byte[file.Length];
@@ -204,7 +213,7 @@ namespace CreateAR.Commons.Unity.Http
             
             return token;
         }
-        
+
         /// <summary>
         /// Sends a file!
         /// </summary>

--- a/CreateAR.Commons.Unity.Http/HttpServiceManager.cs
+++ b/CreateAR.Commons.Unity.Http/HttpServiceManager.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Collections.Generic;
-using CreateAR.Commons.Unity.DataStructures;
 
 namespace CreateAR.Commons.Unity.Http
 {

--- a/CreateAR.Commons.Unity.Http/IHttpService.cs
+++ b/CreateAR.Commons.Unity.Http/IHttpService.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using CreateAR.Commons.Unity.Async;
-using CreateAR.Commons.Unity.DataStructures;
 
 namespace CreateAR.Commons.Unity.Http
 {
@@ -95,13 +94,15 @@ namespace CreateAR.Commons.Unity.Http
         /// <param name="file">The file, which will be named "file".</param>
         /// <param name="offset">The offset in the byte array.</param>
         /// <param name="count">The number of bytes to write.</param>
+        /// <param name="progressCallback">Optional. Invoked with upload progress on supported platforms.</param>
         /// <returns></returns>
         IAsyncToken<HttpResponse<T>> PostFile<T>(
             string url,
             IEnumerable<Tuple<string, string>> fields,
             ref byte[] file,
             int offset,
-            int count);
+            int count,
+            Action<float> progressCallback = null);
 
         /// <summary>
         /// Sends a file through POST.
@@ -110,11 +111,13 @@ namespace CreateAR.Commons.Unity.Http
         /// <param name="url">The url to send the request to.</param>
         /// <param name="fields">Optional fields that will _precede_ the file.</param>
         /// <param name="file">The file, which will be named "file".</param>
+        /// <param name="progressCallback">Optional. Invoked with upload progress on supported platforms.</param>
         /// <returns></returns>
         IAsyncToken<HttpResponse<T>> PostFile<T>(
             string url,
             IEnumerable<Tuple<string, string>> fields,
-            Stream file);
+            Stream file,
+            Action<float> progressCallback = null);
 
         /// <summary>
         /// Sends a file through PUT.
@@ -125,13 +128,15 @@ namespace CreateAR.Commons.Unity.Http
         /// <param name="file">The file, which will be named "file".</param>
         /// <param name="offset">The offset in the byte array.</param>
         /// <param name="count">The number of bytes to write.</param>
+        /// <param name="progressCallback">Optional. Invoked with upload progress on supported platforms.</param>
         /// <returns></returns>
         IAsyncToken<HttpResponse<T>> PutFile<T>(
             string url,
             IEnumerable<Tuple<string, string>> fields,
             ref byte[] file,
             int offset,
-            int count);
+            int count,
+            Action<float> progressCallback = null);
 
         /// <summary>
         /// Sends a file through PUT.
@@ -140,11 +145,13 @@ namespace CreateAR.Commons.Unity.Http
         /// <param name="url">The url to send the request to.</param>
         /// <param name="fields">Optional fields that will _precede_ the file.</param>
         /// <param name="file">The file, which will be named "file".</param>
+        /// <param name="progressCallback">Optional. Invoked with upload progress on supported platforms.</param>
         /// <returns></returns>
         IAsyncToken<HttpResponse<T>> PutFile<T>(
             string url,
             IEnumerable<Tuple<string, string>> fields,
-            Stream file);
+            Stream file,
+            Action<float> progressCallback = null);
 
         /// <summary>
         /// Downloads raw bytes.


### PR DESCRIPTION
Updates interface for optional progress callback. The real progress is all handled in Enkluplayer's UwpHttpService, which can now be used outside of uwp as well since upgrading Enkluplayer's .net version.