### PR TITLE
Feature/auth renegotiation

### DIFF
--- a/CreateAR.Commons.Unity.Http/CreateAR.Commons.Unity.Http.csproj
+++ b/CreateAR.Commons.Unity.Http/CreateAR.Commons.Unity.Http.csproj
@@ -4,14 +4,14 @@
     <TargetFramework>net45</TargetFramework>
     <AssemblyName>CreateAR.Commons.Unity.Http</AssemblyName>
     <RootNamespace>CreateAR.Commons.Unity.Http</RootNamespace>
-    <AssemblyVersion>0.13.5</AssemblyVersion>
+    <AssemblyVersion>2021.6.0</AssemblyVersion>
     <Version>0.13.5</Version>
     <Description>For working with HTTP services.</Description>
     <Copyright>Copyright © 2020 Enklu</Copyright>
     <Authors>Enklu</Authors>
     <IncludeSymbols>True</IncludeSymbols>
     <PackageReleaseNotes>Added ProgressHttpContent</PackageReleaseNotes>
-    <FileVersion>0.13.5</FileVersion>
+    <FileVersion>2021.6.0</FileVersion>
     <Company>Enklu</Company>
     <PackageId>CreateAR.Commons.Unity.Http</PackageId>
     <PackageVersion>0.13.5</PackageVersion>

--- a/CreateAR.Commons.Unity.Http/CreateAR.Commons.Unity.Http.csproj
+++ b/CreateAR.Commons.Unity.Http/CreateAR.Commons.Unity.Http.csproj
@@ -4,14 +4,14 @@
     <TargetFramework>net45</TargetFramework>
     <AssemblyName>CreateAR.Commons.Unity.Http</AssemblyName>
     <RootNamespace>CreateAR.Commons.Unity.Http</RootNamespace>
-    <AssemblyVersion>2021.6.0</AssemblyVersion>
+    <AssemblyVersion>2021.6.2</AssemblyVersion>
     <Version>0.13.5</Version>
     <Description>For working with HTTP services.</Description>
     <Copyright>Copyright © 2020 Enklu</Copyright>
     <Authors>Enklu</Authors>
     <IncludeSymbols>True</IncludeSymbols>
     <PackageReleaseNotes>Added ProgressHttpContent</PackageReleaseNotes>
-    <FileVersion>2021.6.0</FileVersion>
+    <FileVersion>2021.6.2</FileVersion>
     <Company>Enklu</Company>
     <PackageId>CreateAR.Commons.Unity.Http</PackageId>
     <PackageVersion>0.13.5</PackageVersion>

--- a/CreateAR.Commons.Unity.Http/HttpResponseTypeless.cs
+++ b/CreateAR.Commons.Unity.Http/HttpResponseTypeless.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CreateAR.Commons.Unity.Http
+{
+    /// <summary>
+    /// Contains information about the response received from an HTTP endpoint.
+    /// </summary>
+    public class HttpResponseTypeless
+    {
+        /// <summary>
+        /// The response object.
+        /// </summary>
+        public object Payload;
+
+        /// <summary>
+        /// The type of Payload.
+        /// </summary>
+        public Type Type;
+
+        /// <summary>
+        /// Raw response.
+        /// </summary>
+        public byte[] Raw;
+
+        /// <summary>
+        /// Headers.
+        /// </summary>
+        public List<Tuple<string, string>> Headers;
+
+        /// <summary>
+        /// Http status.
+        /// </summary>
+        public long StatusCode;
+
+        /// <summary>
+        /// True iff network was successful-- does not judge successful request
+        /// logic.
+        /// </summary>
+        public bool NetworkSuccess;
+
+        /// <summary>
+        /// Error returned. Populated iff NetworkSuccess is false.
+        /// </summary>
+        public string NetworkError;
+    }
+}

--- a/CreateAR.Commons.Unity.Http/HttpService.cs
+++ b/CreateAR.Commons.Unity.Http/HttpService.cs
@@ -45,11 +45,29 @@ namespace CreateAR.Commons.Unity.Http
             Failed
         }
 
+        /// <summary>
+        /// A stored request to be handled later.
+        /// </summary>
         protected struct RequestPoolRecord
         {
+            /// <summary>
+            /// Underlying Unity request.
+            /// </summary>
             public UnityWebRequest Request;
+            
+            /// <summary>
+            /// The response payload's type.
+            /// </summary>
             public Type Type;
+            
+            /// <summary>
+            /// The token to succeed/fail at renegotiation.
+            /// </summary>
             public AsyncToken<HttpResponseTypeless> Token;
+            
+            /// <summary>
+            /// The response serializtion type.
+            /// </summary>
             public SerializationType Serialization;
         }
 
@@ -576,6 +594,9 @@ namespace CreateAR.Commons.Unity.Http
             }
         }
 
+        /// <summary>
+        /// Generates a HttpResponse<T> token from a Typeless token.
+        /// </summary>
         private AsyncToken<HttpResponse<T>> GenerateTypedToken<T>(IAsyncToken<HttpResponseTypeless> httpToken)
         {
             var rtnToken = new AsyncToken<HttpResponse<T>>();

--- a/CreateAR.Commons.Unity.Http/IHttpService.cs
+++ b/CreateAR.Commons.Unity.Http/IHttpService.cs
@@ -17,6 +17,12 @@ namespace CreateAR.Commons.Unity.Http
         Delete
     }
 
+    public enum RequestType
+    {
+        General,
+        Authentication
+    }
+
     /// <summary>
     /// Defines an HTTP service.
     /// </summary>
@@ -36,6 +42,21 @@ namespace CreateAR.Commons.Unity.Http
         /// Event called when a request is made.
         /// </summary>
         event Action<string, string, Dictionary<string, string>, object> OnRequest;
+
+        /// <summary>
+        /// Event called when a request fails authentication.
+        /// </summary>
+        event Action<string> OnAuthenticationFailure;
+
+        /// <summary>
+        /// Notifies the HttpService that auth information was verified externally.
+        /// </summary>
+        void MarkAuthenticationUpdated();
+
+        /// <summary>
+        /// Notifies the HttpService that auth has failed beyond renegotiation means.
+        /// </summary>
+        void MarkAuthenticationFailed();
         
         /// <summary>
         /// Aborts all http requests.
@@ -59,9 +80,7 @@ namespace CreateAR.Commons.Unity.Http
         /// <param name="payload">The resource to send to this endpoint.</param>
         /// <returns>An IAsyncScope to listen to.</returns>
         /// <exception cref="NullReferenceException"></exception>
-        IAsyncToken<HttpResponse<T>> Post<T>(
-            string url,
-            object payload);
+        IAsyncToken<HttpResponse<T>> Post<T>(string url, object payload, RequestType requestType = RequestType.General);
         
         /// <summary>
         /// Sends a PUT request to an endpoint.
@@ -71,9 +90,7 @@ namespace CreateAR.Commons.Unity.Http
         /// <param name="payload">The resource to send to this endpoint.</param>
         /// <returns>An IAsyncScope to listen to.</returns>
         /// <exception cref="NullReferenceException"></exception>
-        IAsyncToken<HttpResponse<T>> Put<T>(
-            string url,
-            object payload);
+        IAsyncToken<HttpResponse<T>> Put<T>(string url, object payload);
         
         /// <summary>
         /// Sends a DELETE request to an endpoint.
@@ -82,8 +99,7 @@ namespace CreateAR.Commons.Unity.Http
         /// <param name="url">The URL to hit.</param>
         /// <returns>An IAsyncScope to listen to.</returns>
         /// <exception cref="NullReferenceException"></exception>
-        IAsyncToken<HttpResponse<T>> Delete<T>(
-            string url);
+        IAsyncToken<HttpResponse<T>> Delete<T>(string url);
 
         /// <summary>
         /// Sends a file through POST.


### PR DESCRIPTION
The goal of these changes was to be as least intrusive as possible, while providing a mechanism for authentication failures to be resolved without destroying current inflight requests, causing all API/HTTP usage to have to add retry logic.

That being said, I'm not in love with the `RequestType` addition, but it seemed the least intrusive to avoid HTTPService from needing to know more specifics about authentication mechanisms and not being opinionated. If anyone has a better solution, I'm all ears!

### Reference Diagram
![image](https://user-images.githubusercontent.com/4741738/123989941-339d8500-d97e-11eb-8089-b2bc6169235d.png)


### Changes
#### IHttpService
- Added an optional `RequestType` to denote if a POST request is used for Authentication purposes.
- Added an event when authentication failure occurs.
- Added external hooks to allow users of `IHttpService` to notify the implementation of auth renegotiation results.

#### HttpService
- Created an `AuthStance` to dictate whether credentials are assumed valid, in a renegotiation state, or known to have failed irreparably. 
- Created a pool for requests to be kept pending while auth renegotiation occurs.